### PR TITLE
fix: new match user input to only allow digits

### DIFF
--- a/src/components/NewMatchButton/NewMatchForm.tsx
+++ b/src/components/NewMatchButton/NewMatchForm.tsx
@@ -1,32 +1,39 @@
 import fetcher from '@/lib/fetcher';
 import { OpponentsAPIResponse } from '@/pages/api/games/[id]/opponents';
-import { Badge, Box, Center, HStack, Input, Stack, Text } from '@chakra-ui/react';
+import { Box, HStack, Input, Stack, Text } from '@chakra-ui/react';
 import { Game } from '@prisma/client';
 import { useSession } from 'next-auth/react';
 import { useFormContext } from 'react-hook-form';
 import useSWR from 'swr';
-import LoadingIcon from '../LoadingIcon';
-import PlayerAvatar from '../PlayerAvatar';
-import PlayerLink from '../PlayerLink/PlayerLink';
 import { MatchFormInputs } from './NewMatchButton';
-import { groupBy } from 'ramda';
-import { ArrayElement } from '@/lib/types/utils';
-import Fuse from 'fuse.js';
-import { useMemo, useState } from 'react';
+import PlayerPicker from '../PlayerPicker';
 
 type NewMatchFormProps = {
   gameId: Game['id'];
 };
-type Opponent = ArrayElement<OpponentsAPIResponse['opponents']>;
-const byFirstLetter = groupBy<Opponent>(user => user.name?.toLowerCase()[0] || 'other');
 
 const NewMatchForm: React.VFC<NewMatchFormProps> = ({ gameId }) => {
-  const { register } = useFormContext<MatchFormInputs>();
+  const { register, watch, setValue } = useFormContext<MatchFormInputs>();
+  const { data: session } = useSession();
+  const {
+    data: opponentsQuery,
+    error: opponentsError,
+    mutate,
+  } = useSWR<OpponentsAPIResponse>(`/api/games/${gameId}/opponents`, fetcher);
+  register('p2id', { required: true });
+  const p2id = watch('p2id');
+  const players = opponentsQuery?.opponents?.filter(({ id }) => id !== session?.user.id);
 
   return (
     <Stack>
       <Text>Who have you played against?</Text>
-      <PlayerPicker gameId={gameId} />
+      <PlayerPicker
+        players={players}
+        selectedId={p2id}
+        refetch={mutate}
+        isLoading={!opponentsQuery}
+        onSelect={id => setValue('p2id', id)}
+      />
       <Text pt={8} pb={3}>
         What was the score?
       </Text>
@@ -85,81 +92,6 @@ const NewMatchForm: React.VFC<NewMatchFormProps> = ({ gameId }) => {
           />
         </Box>
       </HStack>
-    </Stack>
-  );
-};
-
-type PlayerPickerProps = {
-  gameId: Game['id'];
-};
-const PlayerPicker: React.VFC<PlayerPickerProps> = ({ gameId }) => {
-  const { register, watch, setValue } = useFormContext<MatchFormInputs>();
-  const { p2id } = watch();
-  const { data: opponentsQuery, error: opponentsError } = useSWR<OpponentsAPIResponse>(
-    `/api/games/${gameId}/opponents`,
-    fetcher
-  );
-  const { data: session } = useSession();
-
-  const [search, setSearch] = useState<string | null>(null);
-  const fuse = new Fuse(opponentsQuery?.opponents || [], {
-    keys: ['name'],
-    isCaseSensitive: false,
-  });
-
-  register('p2id', { required: true });
-
-  if (opponentsError) {
-    return <Text>Error loading players</Text>;
-  }
-
-  const opponents = search ? fuse.search(search).map(({ item }) => item) : opponentsQuery?.opponents;
-  const sortedOpponents =
-    opponents
-      ?.filter(({ id }) => id !== session?.user.id)
-      .sort((a, b) => ((a?.name?.[0] || 'z') > (b?.name?.[0] || 'z') ? 1 : -1)) || [];
-
-  const opponentsByFirstLetter = byFirstLetter(sortedOpponents);
-
-  return (
-    <Stack>
-      <Input type="text" onChange={e => setSearch(e.target.value)} placeholder="Type to search players" />
-      <Box h="256px" overflow="auto" bg="gray.100" borderRadius="xl">
-        {opponentsByFirstLetter ? (
-          Object.entries(opponentsByFirstLetter).map(([firstLetter, opponents]) => {
-            return (
-              <Stack key={firstLetter} spacing={0}>
-                <Box pl={16} py={1} position="sticky" top="0" zIndex="docked" bg="gray.50" color="gray.600">
-                  {firstLetter.toUpperCase()}
-                </Box>
-                {opponents.map(user => {
-                  const [score] = user?.scores;
-                  return (
-                    <HStack
-                      p={4}
-                      bg={p2id === user.id ? 'gray.300' : undefined}
-                      onClick={() => setValue('p2id', user.id)}
-                      key={user.id}
-                      as="button"
-                      type="button"
-                    >
-                      <HStack flexGrow={1} spacing={4} flexShrink={1}>
-                        <PlayerAvatar user={user} />
-                        <PlayerLink name={user.name} noOfLines={1} />
-                      </HStack>
-                      {score?.points ? <Badge bg={'white'}>{score?.points} pts</Badge> : <Badge>never played</Badge>}
-                    </HStack>
-                  );
-                })}
-              </Stack>
-            );
-          })
-        ) : (
-          <Center p={8}>
-            <LoadingIcon size={8} color="white" />
-          </Center>
-        )}
-      </Box>
     </Stack>
   );
 };

--- a/src/components/PlayerPicker/PlayerItem.tsx
+++ b/src/components/PlayerPicker/PlayerItem.tsx
@@ -1,0 +1,40 @@
+import { Badge, HStack } from '@chakra-ui/react';
+import { User } from '@prisma/client';
+import { motion } from 'framer-motion';
+import PlayerAvatar from '../PlayerAvatar';
+import PlayerLink from '../PlayerLink/PlayerLink';
+import { Player } from './PlayerPicker';
+
+type PlayerItemProps = {
+  player: Player;
+  isSelected?: boolean;
+  onSelect?: (id: User['id']) => void;
+};
+const MotionHStack = motion(HStack);
+
+const PlayerItem: React.VFC<PlayerItemProps> = ({ player, isSelected, onSelect }) => {
+  const [score] = player?.scores;
+  return (
+    <MotionHStack
+      layout
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      layoutId={player.id}
+      p={4}
+      overflow="hidden"
+      bg={isSelected ? 'gray.300' : undefined}
+      onClick={() => onSelect?.(player.id)}
+      as="button"
+      type="button"
+    >
+      <HStack flexGrow={1} spacing={4} flexShrink={1}>
+        <PlayerAvatar user={player} />
+        <PlayerLink name={player.name} noOfLines={1} />
+      </HStack>
+      {score?.points ? <Badge bg={'white'}>{score?.points} pts</Badge> : <Badge>never played</Badge>}
+    </MotionHStack>
+  );
+};
+
+export default PlayerItem;

--- a/src/components/PlayerPicker/PlayerPicker.tsx
+++ b/src/components/PlayerPicker/PlayerPicker.tsx
@@ -1,0 +1,103 @@
+import { sortAlphabetically } from '@/lib/arrays';
+import { ArrayElement } from '@/lib/types/utils';
+import { OpponentsAPIResponse } from '@/pages/api/games/[id]/opponents';
+import { Box, Button, Input, Stack, Text } from '@chakra-ui/react';
+import { AnimatePresence, AnimateSharedLayout, motion } from 'framer-motion';
+import Fuse from 'fuse.js';
+import { groupBy } from 'ramda';
+import { useMemo, useState } from 'react';
+import PlayerItem from './PlayerItem';
+
+export type Player = ArrayElement<OpponentsAPIResponse['opponents']>;
+
+type PlayerPickerProps = {
+  players?: Player[];
+  onSelect: (id: Player['id']) => void;
+  selectedId?: Player['id'];
+  isLoading?: boolean;
+  isError?: boolean;
+  refetch?: () => void;
+};
+
+const groupByFirstLetter = groupBy<Player>(user => user.name?.toLowerCase()[0] || 'other');
+const MotionBox = motion(Box);
+
+const PlayerPicker: React.VFC<PlayerPickerProps> = ({ players, onSelect, selectedId, isLoading, isError, refetch }) => {
+  const [search, setSearch] = useState<string>('');
+  const fuse = useMemo(
+    () =>
+      new Fuse(players || [], {
+        keys: ['name'],
+        isCaseSensitive: false,
+      }),
+    [players]
+  );
+
+  const playerList: [string, Player[]][] = search
+    ? [
+        [
+          'results',
+          fuse
+            .search(search)
+            .sort((a, b) => (a.score || 0) - (b.score || 0))
+            .map(({ item }) => item),
+        ],
+      ]
+    : Object.entries(groupByFirstLetter(sortAlphabetically(players || [], player => player.name || '')));
+
+  if (isError)
+    return (
+      <Box p={4} textAlign="center" bg="red.100" borderRadius="xl" color="red.600">
+        <Text mb={2}>Error loading players :(</Text>
+        {refetch && (
+          <Button isLoading={isLoading} onClick={() => refetch()}>
+            Retry
+          </Button>
+        )}
+      </Box>
+    );
+
+  return (
+    <Stack>
+      <Input
+        type="text"
+        onChange={e => setSearch(e.target.value)}
+        placeholder="Type to search players"
+        isDisabled={isLoading}
+      />
+      <Stack spacing={0} h="256px" overflow="auto" bg="gray.100" borderRadius="xl">
+        <AnimateSharedLayout>
+          {playerList.map(([divider, opponents]) => {
+            return (
+              <Stack spacing={0} key={divider}>
+                <AnimatePresence>
+                  <MotionBox
+                    layout
+                    key={divider}
+                    layoutId={divider}
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    pl={16}
+                    py={1}
+                    bg="gray.50"
+                    color="gray.400"
+                    letterSpacing="wider"
+                    fontSize="sm"
+                  >
+                    {divider.toUpperCase()}
+                  </MotionBox>
+                  {opponents.map(user => (
+                    <PlayerItem isSelected={selectedId === user.id} player={user} key={user.id} onSelect={onSelect} />
+                  ))}
+                </AnimatePresence>
+              </Stack>
+            );
+          })}
+        </AnimateSharedLayout>
+      </Stack>
+    </Stack>
+  );
+};
+
+export default PlayerPicker;

--- a/src/components/PlayerPicker/index.ts
+++ b/src/components/PlayerPicker/index.ts
@@ -1,0 +1,1 @@
+export { default } from './PlayerPicker';

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,5 +1,5 @@
 import hideScrollbar from '@/lib/styleUtils';
-import { Box, Button, HStack, Stack, Text } from '@chakra-ui/react';
+import { Box, HStack, Stack, Text } from '@chakra-ui/react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import IconBlur from '../IconBlur/IconBlur';
@@ -18,8 +18,8 @@ const Sidebar: React.VFC<SidebarProps> = ({ items }) => {
       zIndex="docked"
       overflow="scroll"
       css={hideScrollbar}
-      position={{ base: 'sticky', md: 'static' }}
-      top={2}
+      position={{ base: 'fixed', md: 'static' }}
+      bottom={'calc(env(safe-area-inset-bottom, 0.5vh) + 16px)'}
       boxShadow={{ base: 'lg', md: 'none' }}
     >
       {items?.map(item => (

--- a/src/lib/arrays.ts
+++ b/src/lib/arrays.ts
@@ -1,0 +1,2 @@
+export const sortAlphabetically = <T>(array: T[], valueFn: (item: T) => string | undefined) =>
+  array.sort((a, b) => ((valueFn(a)?.[0] || 'z') > (valueFn(b)?.[0] || 'z') ? 1 : -1));

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -2,7 +2,6 @@ import NextAuth from 'next-auth';
 import SlackProvider from 'next-auth/providers/slack';
 import EmailProvider from 'next-auth/providers/email';
 import GitHubProvider from 'next-auth/providers/github';
-import CredentialsProvider from 'next-auth/providers/credentials';
 import prisma from '@/lib/prisma';
 import PrismaAdapter from '@/lib/adapter';
 
@@ -23,39 +22,6 @@ if (process.env.GITHUB_CLIENT_ID && process.env.GITHUB_CLIENT_SECRET) {
     GitHubProvider({
       clientId: process.env.GITHUB_CLIENT_ID,
       clientSecret: process.env.GITHUB_CLIENT_SECRET,
-    })
-  );
-}
-
-if (process.env.ENABLE_EMAIL_AUTH === 'true') {
-  providers.push(
-    CredentialsProvider({
-      name: 'Developer Mode',
-      credentials: {
-        email: { label: 'Email', type: 'text', placeholder: 'me@saltplay.app' },
-      },
-      async authorize(credentials, req) {
-        if (!credentials?.email) return null;
-
-        const user = await prisma.user.findUnique({ where: { email: credentials.email } });
-
-        const random = Math.floor(Math.random() * 300) + 100;
-
-        if (user) {
-          const { id, email, name, image } = user;
-          return { id, email, name, image };
-        }
-
-        const newUser = await prisma.user.create({
-          data: {
-            email: credentials.email,
-            name: credentials.email.split('@')[0],
-            image: `https://placekitten.com/${random}/${random}`,
-          },
-        });
-        const { id, email, name, image } = newUser;
-        return { id, email, name, image };
-      },
     })
   );
 }


### PR DESCRIPTION
# Overview

This PR aims to fix the mobile keyboard when picking a match score. It would previously allow letters and symbols, which is bad for UX.

Took the chance to refactor the PlayerPicker (the menu that allows you to select an opponent you played against) to no longer alphabetically order when searching.

## What we have done

- Added props to handle keyboard on mobile
- Made PlayerPicker into its own component which looks and feel awesome now

## How to test

- When selecting a score the keyboard should be as follows: 
![image](https://user-images.githubusercontent.com/45042736/148655206-dd658371-7052-419f-b5dd-094f9093ac58.png)
- When searching for players on the new window, you shoudl see animated results. I know it looks AWESOME


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added all necessary code documentation and specifications
- [x] I have performed manual tests to ensure the system is working as expected
- [ ] I have created automated tests to replicate my manual testing automatically
