### PR TITLE
fix: p1 appearing twice on slack notification

### DIFF
--- a/src/pages/api/matches/index.ts
+++ b/src/pages/api/matches/index.ts
@@ -26,7 +26,7 @@ const updatePlayerPoints = async (data: Pick<Match, 'gameid' | 'p1id' | 'p2id' |
       await notifyMatchOnSlack({
         gameId: data.gameid,
         p1: { id: data.p1id, score: data.p1score },
-        p2: { id: data.p1id, score: data.p2score },
+        p2: { id: data.p2id, score: data.p2score },
       });
     } catch {
       console.error('Failed to notify match on slack');


### PR DESCRIPTION
# Overview

Slack notifications were showing up player 1 twice because of a typo

## What we have done

- replaced p1 with p2 when passing on to slack.

## How to test

- Create a match and see on slack, it should not display the same name on both sides.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added all necessary code documentation and specifications
- [x] I have performed manual tests to ensure the system is working as expected
- [ ] I have created automated tests to replicate my manual testing automatically
