### PR TITLE
feat: enable p3 colour gamut colours on branding

### DIFF
--- a/src/components/Logo/Logo.tsx
+++ b/src/components/Logo/Logo.tsx
@@ -11,6 +11,18 @@ const Logo: ChakraComponent<'div', {}> = props => {
           fill="url(#paint0_linear_3049_7542)"
         />
         <defs>
+          <style type="text/css" jsx>
+            {`
+              .stop1 {
+                stop-color: #fbb826;
+                stop-color: color(display-p3 1 0.638 0);
+              }
+              .stop2 {
+                stop-color: #fe33a1;
+                stop-color: color(display-p3 1 0 0.574);
+              }
+            `}
+          </style>
           <linearGradient
             id="paint0_linear_3049_7542"
             x1="100"
@@ -19,8 +31,8 @@ const Logo: ChakraComponent<'div', {}> = props => {
             y2="67.0213"
             gradientUnits="userSpaceOnUse"
           >
-            <stop stopColor="#FBB826" />
-            <stop offset="1" stopColor="#FE33A1" />
+            <stop className="stop1" />
+            <stop offset="1" className="stop2" />
           </linearGradient>
         </defs>
       </svg>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -32,7 +32,17 @@ const Home: NextPage<HomeProps> = ({ offices, players }) => {
           >
             work hard,
             <br />
-            <Text as="span" bg="linear-gradient(-135deg, #FBB826, #FE33A1)" backgroundClip="text">
+            <Text
+              as="span"
+              bg={[
+                // @ts-ignore chakra doesn't offer array as props as Emotion does, but it works!
+                [
+                  'linear-gradient(-135deg, #FBB826, #FE33A1)',
+                  'linear-gradient(-135deg, color(display-p3 1 0.638 0), color(display-p3 1 0 0.574))',
+                ],
+              ]}
+              backgroundClip="text"
+            >
               play hard.
             </Text>
           </Heading>

--- a/src/theme/components/Button.ts
+++ b/src/theme/components/Button.ts
@@ -20,7 +20,12 @@ const variantSubtle: SystemStyleFunction = props => {
 };
 
 const variantPrimary: SystemStyleObject = {
-  bg: 'linear-gradient(-135deg, #FBB826, #FE33A1)',
+  bg: [
+    [
+      'linear-gradient(-135deg, #FBB826, #FE33A1)',
+      'linear-gradient(-135deg, color(display-p3 1 0.638 0), color(display-p3 1 0 0.574))',
+    ],
+  ],
   fontWeight: 'bold',
   color: 'white',
   _hover: {


### PR DESCRIPTION
# Overview

Nowadays there's plenty of compatibility with the new [P3 Wider Colour Gamut Standard](https://webkit.org/blog/10042/wide-gamut-color-in-css-with-display-p3/). By adding a few properties we can add functionality to support it and make our app strikingly bright.

## What we have done

- Added the new props for P3 colour gamut
- Added graceful degradation where if the colours are not supported it'll simply fall back to sRGB compatible colours

## How to test

- Test out the preview app on Safari, on Mac or iOS. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added all necessary code documentation and specifications
- [x] I have performed manual tests to ensure the system is working as expected
- [ ] I have created automated tests to replicate my manual testing automatically
