### PR TITLE
fix: new match API not adding new PlayerScore

### DIFF
--- a/src/pages/api/matches/index.ts
+++ b/src/pages/api/matches/index.ts
@@ -48,13 +48,17 @@ const updatePlayersPoints = async (
   if (data.leftscore === data.rightscore) return;
 
   const newScores = [
-    ...leftPoints.map(player => ({
-      id: player.playerid,
-      newScore: player.points + matchPoints * (data.leftscore > data.rightscore ? 1 : -1),
+    ...data.left.map(player => ({
+      id: player.id,
+      newScore:
+        (leftPoints.find(p => p.playerid === player.id)?.points || STARTING_POINTS) +
+        matchPoints * (data.leftscore > data.rightscore ? 1 : -1),
     })),
-    ...rightPoints.map(player => ({
-      id: player.playerid,
-      newScore: player.points + matchPoints * (data.leftscore < data.rightscore ? 1 : -1),
+    ...data.right.map(player => ({
+      id: player.id,
+      newScore:
+        (rightPoints.find(p => p.playerid === player.id)?.points || STARTING_POINTS) +
+        matchPoints * (data.leftscore < data.rightscore ? 1 : -1),
     })),
   ];
 


### PR DESCRIPTION
# Overview

A small issue on the new match API route was causing new PlayerScores to prevent being created. Not a glitch, but a mistake on my part that is now fixed!

Need to write some unit tests asap.

## What we have done

- Updated the base array for establishing updates or additions to PlayerScores.

## How to test

- Create a match with a player that says NEVER PLAYED on the new match form.
- They should now appear on the leaderboard

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added all necessary code documentation and specifications
- [x] I have performed manual tests to ensure the system is working as expected
- [ ] I have created automated tests to replicate my manual testing automatically
