### PR TITLE
fix: points distribution api + small tweaks

### DIFF
--- a/src/components/NewMatchButton/steps/Teams.tsx
+++ b/src/components/NewMatchButton/steps/Teams.tsx
@@ -5,7 +5,7 @@ import fetcher from '@/lib/fetcher';
 import { STARTING_POINTS } from '@/lib/leaderboard';
 import { OpponentsAPIResponse } from '@/pages/api/games/[id]/opponents';
 import getUserGradient from '@/theme/palettes';
-import { Badge, Box, Circle, HStack, Text } from '@chakra-ui/react';
+import { Badge, Box, Circle, HStack, Skeleton, Text } from '@chakra-ui/react';
 import { Game, User } from '@prisma/client';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useSession } from 'next-auth/react';
@@ -79,6 +79,15 @@ const Teams: React.VFC<TeamsProps> = ({ gameId, maxPlayersPerTeam, onFinish }) =
     }
     setSelectedSide(side);
   };
+
+  if (!opponentsQuery)
+    return (
+      <HStack as="aside" spacing={1} mb={4}>
+        <Skeleton flex={1} h="146px" borderRadius="lg" />
+        <Badge>Vs</Badge>
+        <Skeleton flex={1} h="146px" borderRadius="lg" />
+      </HStack>
+    );
 
   return (
     <Box>

--- a/src/components/PlayerPicker/PlayerPicker.tsx
+++ b/src/components/PlayerPicker/PlayerPicker.tsx
@@ -1,6 +1,6 @@
 import { sortAlphabetically } from '@/lib/arrays';
 import { Box, Button, HStack, Input, Stack, Text } from '@chakra-ui/react';
-import { IoSearchCircle } from 'react-icons/io5';
+import { IoSearchCircle, IoCloseCircleOutline } from 'react-icons/io5';
 import { AnimatePresence, AnimateSharedLayout, motion } from 'framer-motion';
 import { groupBy } from 'ramda';
 import { useMemo, useState } from 'react';
@@ -71,10 +71,29 @@ const PlayerPicker: React.VFC<PlayerPickerProps> = ({
           id="search"
           type="text"
           onChange={e => setSearch(e.target.value)}
+          value={search}
           placeholder="Type to search…"
           isDisabled={isLoading}
           variant="unstyled"
+          flexGrow={1}
+          autoComplete="off"
         />
+        {search && (
+          <AnimatePresence>
+            <MotionBox
+              initial={{ scale: 0 }}
+              animate={{ scale: 1 }}
+              exit={{ scale: 0 }}
+              as="button"
+              onClick={() => setSearch('')}
+              color="gray.400"
+              _hover={{ color: 'gray.600' }}
+              px={1}
+            >
+              <IoCloseCircleOutline size="24" />
+            </MotionBox>
+          </AnimatePresence>
+        )}
       </HStack>
       <AnimateSharedLayout>
         {playersList.map(([divider, opponents]) => {
@@ -104,7 +123,10 @@ const PlayerPicker: React.VFC<PlayerPickerProps> = ({
                     selectedColour={selectedColour}
                     player={user}
                     key={user.id}
-                    onSelect={onSelect}
+                    onSelect={player => {
+                      onSelect(player);
+                      setSearch('');
+                    }}
                   />
                 ))}
               </AnimatePresence>

--- a/src/pages/[office]/dashboard.tsx
+++ b/src/pages/[office]/dashboard.tsx
@@ -7,7 +7,7 @@ import Leaderboard from '@/components/Leaderboard';
 export const getOfficeBySlug = async (slug: string) =>
   await prisma.office.findUnique({
     where: { slug },
-    select: { games: { select: { id: true, name: true } } },
+    select: { games: { orderBy: { id: 'asc' }, select: { id: true, name: true } } },
   });
 
 type OfficePageProps = {

--- a/src/pages/api/matches/index.ts
+++ b/src/pages/api/matches/index.ts
@@ -26,10 +26,14 @@ const updatePlayersPoints = async (
     select: { playerid: true, points: true },
   });
 
-  const leftTotalPoints = leftPoints.reduce((acc, cur) => acc + (cur.points || STARTING_POINTS), 0);
-  const rightTotalPoints = rightPoints.reduce((acc, cur) => acc + (cur.points || STARTING_POINTS), 0);
+  const leftAveragePoints = Math.ceil(
+    leftPoints.reduce((acc, cur) => acc + (cur.points || STARTING_POINTS), 0) / data.left.length
+  );
+  const rightAveragePoints = Math.ceil(
+    rightPoints.reduce((acc, cur) => acc + (cur.points || STARTING_POINTS), 0) / data.right.length
+  );
 
-  const matchPoints = calculateMatchPoints(leftTotalPoints, rightTotalPoints, data.leftscore - data.rightscore);
+  const matchPoints = calculateMatchPoints(leftAveragePoints, rightAveragePoints, data.leftscore - data.rightscore);
 
   if (process.env.ENABLE_SLACK_MATCH_NOTIFICATION) {
     try {


### PR DESCRIPTION
# Overview

Points distro API was taking total points as opposed to avg; as we have shifted from ratio to the absolute difference in points, it was exaggerating the outcome.

## What we have done

- Changed the algorithm from total to average points
- Fixed the ordering of sidebar elements to always be in ascending id order (it may feel random to users, but not for us)
- Added skeleton effects to when loading opponents to avoid rendering an empty window on the opponents selection
- Experimenting with better search funcitonality: introduced an 'x' icon to erase search; whenever you click on a user it clears search

## Blockers/Issues

- As the number of players grows we'll have to start thinking about virtualising the list so the browser doesn't hang

## How to test

- Create a very unbalanced match and see if the points changed are reasonable
- Use the search
- Check if a skeleton effect appears before getting the users
- Check if sidebar on office and inside a game remain the same order

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added all necessary code documentation and specifications
- [x] I have performed manual tests to ensure the system is working as expected
- [ ] I have created automated tests to replicate my manual testing automatically
