### PR TITLE
fix: force enGB for date locale

### DIFF
--- a/src/components/MatchSummary/MatchSummary.tsx
+++ b/src/components/MatchSummary/MatchSummary.tsx
@@ -4,6 +4,7 @@ import canDeleteMatch from '@/lib/canDeleteMatch';
 import { Box, HStack, Text, VStack } from '@chakra-ui/react';
 import { Match, User } from '@prisma/client';
 import formatRelative from 'date-fns/formatRelative';
+import { enGB } from 'date-fns/locale';
 import { useSession } from 'next-auth/react';
 import { Fragment, useState } from 'react';
 import DeleteMatchButton from './DeleteButton';
@@ -74,7 +75,7 @@ const MatchSummary: React.VFC<MatchSummaryProps> = ({
           fontSize="xs"
           letterSpacing="wide"
         >
-          {formatRelative(new Date(createdAt), new Date())} {officeName && `at ${officeName}`}
+          {formatRelative(new Date(createdAt), new Date(), { locale: enGB })} {officeName && `at ${officeName}`}
         </Box>
       )}
       <HStack p={4} w="100%" justifyContent="center" gap={4}>


### PR DESCRIPTION
# Overview

This is a bug fix attempt for when pages generated on different nodes would use their settings which may not be entirely reliant on the client's locale formatting.

By being explicit about our locale when formatting date, we guarantee that pages generated on the edge will keep the same format.

## What we have done

- Added `enGB`  as the locale for the `MatchSummary` component.
- Future steps: if we ever display any more dates, set up a default locale for `date-fns`

## How to test

- View matches that happened over a week ago, and check whether the format of every one on every office matches DD/MM/YYYY

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added all necessary code documentation and specifications
- [x] I have performed manual tests to ensure the system is working as expected
- [x] I have created automated tests to replicate my manual testing automatically
