### PR TITLE
fix: readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ After cloning the repository:
 #### Setup docker container
 
 ```bash
-docker compose up -D
+docker compose up -d
 ```
 
 This will spin up a local postgres database and required services.


### PR DESCRIPTION
# Overview

Old readme had the docker set up as
```
docker compose up -D
```
But the capitalised "D" is not recognised and throws this error:
```
unknown shorthand flag: 'D' in -D
```

Have now changed it to the correct command "d" ([documentation](unknown shorthand flag: 'D' in -D))
```
docker compose up -d
```


## What we have done

- Changed the letter "D" to the letter "d" in the docker setup instructions


## How to test

- Run `docker compose up -d` and watch it succeed

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added all necessary code documentation and specifications
- [x] I have performed manual tests to ensure the system is working as expected
- [ ] I have created automated tests to replicate my manual testing automatically
